### PR TITLE
fix: repair broken lint/build pipeline and hydration warning

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,6 @@
 import { dirname } from "path";
 import { fileURLToPath } from "url";
 import { FlatCompat } from "@eslint/eslintrc";
-import { rules } from "eslint-config-prettier";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -11,15 +10,20 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
+  {
+    ignores: ["src/generated/**"],
+  },
   ...compat.extends("next/core-web-vitals", "next/typescript", "prettier"),
-  rules({
-    "@typescript-eslint/no-unused-vars": [
-      "error",
-      {
-        ignoreRestSiblings: true,
-      },
-    ],
-  }),
+  {
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          ignoreRestSiblings: true,
+        },
+      ],
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/src/app/(main)/editor/forms/EducationForm.tsx
+++ b/src/app/(main)/editor/forms/EducationForm.tsx
@@ -46,7 +46,7 @@ export default function EducationForm({
     },
   });
 
-  let lastValuesRef = useRef<string>("");
+  const lastValuesRef = useRef<string>("");
   useEffect(() => {
     const debouncedValidateAndUpdate = debounce(async () => {
       const currentValues = form.getValues();

--- a/src/app/(main)/editor/forms/GeneralInfoForm.tsx
+++ b/src/app/(main)/editor/forms/GeneralInfoForm.tsx
@@ -27,7 +27,7 @@ export default function GeneralInfoForm({
     },
   });
 
-  let lastValuesRef = useRef({});
+  const lastValuesRef = useRef({});
   useEffect(() => {
     const debouncedValidateAndUpdate = debounce(async (values) => {
       const isSame =

--- a/src/app/(main)/editor/forms/PersonalInfoForm.tsx
+++ b/src/app/(main)/editor/forms/PersonalInfoForm.tsx
@@ -11,7 +11,7 @@ import { personalInfoSchema, PersonalInfoValues } from "@/lib/validation";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
-import { debounce, last, set } from "lodash";
+import { debounce } from "lodash";
 import { EditorFormProps } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 
@@ -43,7 +43,7 @@ export default function PersonalInfoForm({
       : {};
   }
 
-  let lastValuesRef = useRef({});
+  const lastValuesRef = useRef({});
   useEffect(() => {
     const debouncedValidateAndUpdate = debounce(async (values) => {
       const photoFileObj = convertFile2Obj(values.photo as File);

--- a/src/app/(main)/editor/forms/SkillsForm.tsx
+++ b/src/app/(main)/editor/forms/SkillsForm.tsx
@@ -26,26 +26,29 @@ export default function SkillsForm({
     },
   });
 
-  let lastValuesRef = useRef({});
+  const lastValuesRef = useRef({});
   useEffect(() => {
-    const debouncedValidateAndUpdate = debounce(async (values) => {
-      const isSame =
-        JSON.stringify(values) === JSON.stringify(lastValuesRef.current);
-      if (isSame) return; // prevent re-triggering for the same values
+    const debouncedValidateAndUpdate = debounce(
+      async (values: { skills?: (string | undefined)[] }) => {
+        const isSame =
+          JSON.stringify(values) === JSON.stringify(lastValuesRef.current);
+        if (isSame) return; // prevent re-triggering for the same values
 
-      const isValid = await form.trigger();
-      if (!isValid) return;
+        const isValid = await form.trigger();
+        if (!isValid) return;
 
-      lastValuesRef.current = values; // update last validated values
-      setResumeData({
-        ...resumeData,
-        skills:
-          values.skills
-            ?.filter((skill: any) => skill !== undefined)
-            .map((skill: any) => skill.trim())
-            .filter((skill: any) => skill !== "") || [],
-      });
-    }, 500);
+        lastValuesRef.current = values; // update last validated values
+        setResumeData({
+          ...resumeData,
+          skills:
+            values.skills
+              ?.filter((skill): skill is string => skill !== undefined)
+              .map((skill) => skill.trim())
+              .filter((skill) => skill !== "") || [],
+        });
+      },
+      500,
+    );
 
     const subscription = form.watch((values) => {
       debouncedValidateAndUpdate(values);

--- a/src/app/(main)/editor/forms/SummaryForm.tsx
+++ b/src/app/(main)/editor/forms/SummaryForm.tsx
@@ -26,7 +26,7 @@ export default function SummaryForm({
     },
   });
 
-  let lastValuesRef = useRef({});
+  const lastValuesRef = useRef({});
   useEffect(() => {
     const debouncedValidateAndUpdate = debounce(async (values) => {
       const isSame =

--- a/src/app/(main)/editor/forms/WorkExperienceForm.tsx
+++ b/src/app/(main)/editor/forms/WorkExperienceForm.tsx
@@ -49,7 +49,7 @@ export default function WorkExperienceForm({
     },
   });
 
-  let lastValuesRef = useRef<string>("");
+  const lastValuesRef = useRef<string>("");
   useEffect(() => {
     const debouncedValidateAndUpdate = debounce(async () => {
       const currentValues = form.getValues();

--- a/src/app/(main)/editor/useAutoSaveResume.tsx
+++ b/src/app/(main)/editor/useAutoSaveResume.tsx
@@ -4,7 +4,6 @@ import { useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { saveResume } from "./actions";
-import { Button } from "@/components/ui/button";
 import { fileReplacer } from "@/lib/utils";
 
 export default function useAutoSaveResume(resumeData: ResumeValues) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
   return (
     <ClerkProvider>
       <html lang="en" suppressHydrationWarning>
-        <body className={inter.className}>
+        <body className={inter.className} suppressHydrationWarning>
           <ThemeProvider
             attribute={"class"}
             defaultTheme="system"

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,9 +1,6 @@
 import { Loader2 } from "lucide-react";
-import { FC } from "react";
 
-interface ComponentProps {}
-
-const loading: FC<ComponentProps> = () => {
+const loading = () => {
   return (
     <div className="flex h-screen items-center justify-center bg-zinc-500/70">
       <Loader2 className="mx-auto my-6 animate-spin" />

--- a/src/components/premium/PremiumModal.tsx
+++ b/src/components/premium/PremiumModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FC, useState } from "react";
+import { useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -14,12 +14,10 @@ import { toast } from "sonner";
 import { createCheckoutSession } from "./actions";
 import { env } from "@/env";
 
-interface ComponentProps {}
-
 const premiumFeatures = ["AI tools", "Up to 3 resumes"];
 const premiumPlusFeatures = ["Infinite resumes", "Design Customizations"];
 
-const PremiumModal: FC<ComponentProps> = () => {
+const PremiumModal = () => {
   const { open, setOpen } = usePremiumModal();
 
   const [loading, setLoading] = useState(false);


### PR DESCRIPTION
eslint.config.mjs called eslint-config-prettier's `rules` export as a function, but it's a config object — this crashed `next lint` outright and silently broke `next build`, since Next.js runs lint as part of the build and treats errors as failures. Also excluded the generated Prisma client from linting, since it was being linted as source.

Fixed the real lint/type errors this uncovered (unused imports, `let` vs `const`, `any` types, empty interfaces) so the build passes again, and added suppressHydrationWarning to <body> in the root layout to silence a hydration mismatch caused by a browser extension injecting attributes before React hydrates.